### PR TITLE
Including iterator to avoid compilation problems with some compilers.

### DIFF
--- a/src/npy.hpp
+++ b/src/npy.hpp
@@ -35,6 +35,7 @@
 #include <algorithm>
 #include <regex>
 #include <unordered_map>
+#include <iterator>
 
 
 namespace npy {


### PR DESCRIPTION
Simple modification to import the iterator library. It avoids some conflicts appearing in the essential build tools of Ubuntu, for example.